### PR TITLE
use `/usr/bin/env bash` shebang for compatibility with *nix systems

### DIFF
--- a/pg_backup.sh
+++ b/pg_backup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###########################
 ####### LOAD CONFIG #######

--- a/pg_backup_rotated.sh
+++ b/pg_backup_rotated.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###########################
 ####### LOAD CONFIG #######
@@ -200,4 +200,4 @@ find $BACKUP_DIR -maxdepth 1 -mtime +$DAYS_TO_KEEP -name "*-daily" -exec rm -rf 
 perform_backups "-daily"
 
 # perform S3 sync
-aws s3 sync $BACKUP_DIR s3://$AWS_BUCKET 
+aws s3 sync $BACKUP_DIR s3://$AWS_BUCKET


### PR DESCRIPTION
I had to fix this because on FreeBSD (and on many other *nix systems) bash is installed under `/usr/bin/bash`.

Using `usr/bin/env` it will recognise the right path to `bash` command.